### PR TITLE
Fix for "Could not load default.cfg" during build

### DIFF
--- a/neo/TypeInfo/main.cpp
+++ b/neo/TypeInfo/main.cpp
@@ -117,10 +117,10 @@ const char *Sys_Cwd( void ) {
 	_getcwd( cwd, sizeof( cwd ) - 1 );
 	cwd[sizeof( cwd ) - 1] = 0;
 
-	int i = idStr::FindText( cwd, CD_BASEDIR, false );
+	/*int i = idStr::FindText( cwd, CD_BASEDIR, false );
 	if ( i >= 0 ) {
 		cwd[i + strlen( CD_BASEDIR )] = '\0';
-	}
+	}*/
 
 	return cwd;
 }


### PR DESCRIPTION
I ran into some problems while running the stock project in Visual Studio 2010, it seems Sys_Cwd has the right value up until it tries to find "Doom" inside the cwd. Because mine contained "doom3.gpl" it returned "doom".
