### PR TITLE
small clean-up for build log.

### DIFF
--- a/neo/SConstruct
+++ b/neo/SConstruct
@@ -3,7 +3,7 @@
 # TTimo <ttimo@idsoftware.com>
 # http://scons.sourceforge.net
 
-import sys, os, time, commands, re, pickle, StringIO, popen2, commands, pdb, zipfile, string
+import sys, os, time, commands, re, pickle, StringIO, commands, pdb, zipfile, string
 import SCons
 
 sys.path.append( 'sys/scons' )

--- a/neo/sys/scons/Setup.py
+++ b/neo/sys/scons/Setup.py
@@ -1,4 +1,4 @@
-import sys, os, string, time, commands, re, pickle, StringIO, popen2, commands, pdb, zipfile, tempfile
+import sys, os, string, time, commands, re, pickle, StringIO, commands, pdb, zipfile, tempfile
 
 import scons_utils
 

--- a/neo/sys/scons/scons_utils.py
+++ b/neo/sys/scons/scons_utils.py
@@ -1,5 +1,5 @@
 # -*- mode: python -*-
-import sys, os, string, time, commands, re, pickle, StringIO, popen2, commands, pdb, zipfile, tempfile
+import sys, os, string, time, commands, re, pickle, StringIO, commands, pdb, zipfile, tempfile
 import SCons
 
 # need an Environment and a matching buffered_spawn API .. encapsulate


### PR DESCRIPTION
Fix depecated warning of popen2 from build log.
And, already, nowhere use the popen2.

Signed-off-by: Homin Lee homin.lee@suapapa.net
